### PR TITLE
fix certifi certificates with OpenSSL<1.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aldryn/base:3.0
+FROM aldryn/base:3.1
 ADD build /build
 ENV NPS_VERSION=1.9.32.3\
     NGINX_VERSION=1.6.3\

--- a/build/fix_certifi_hack.pth
+++ b/build/fix_certifi_hack.pth
@@ -1,0 +1,1 @@
+import fix_certifi_hack

--- a/build/fix_certifi_hack.py
+++ b/build/fix_certifi_hack.py
@@ -1,0 +1,30 @@
+# Workaround for openssl<1.0.2 not supporting 2048bit certificates correctly
+# (newest certifi packages only provide 2048bit certs by default)
+# This is a nasty place to put this code, but other places did not work.
+# e.g setting REQUESTS_CA_BUNDLE globally breaks pip install, since it also
+# uses a vendored in version of requests under the hood.
+import sys
+import os
+
+
+if 'REQUESTS_CA_BUNDLE' not in os.environ:
+    try:
+        import certifi
+    except ImportError:
+        # certifi not installed - no need to do any thing.
+        # requests will use the outdated bundled certs.
+        # Not ideal, but nothing we can do.
+        pass
+    else:
+        import ssl
+        from distutils.version import LooseVersion
+        v_installed = ssl.OPENSSL_VERSION.split(" ")[1]
+        v_2048bit_capable = '1.0.2'
+        if LooseVersion(v_installed) < LooseVersion(v_2048bit_capable):
+            # OpenSSL<1.0.2 can't handle 2048bit certs. Use the less secure,
+            # but up-to-date and working 1024bit certs from certifi.
+            os.environ['REQUESTS_CA_BUNDLE'] = certifi.old_where()
+        else:
+            # we have OpenSSL>=1.0.2, so using the default up-to-date 2048bit
+            # certs will not be a problem.
+            pass

--- a/build/prepare
+++ b/build/prepare
@@ -5,3 +5,5 @@
 /build/bower.sh
 cp /build/addons-dev.pth /virtualenv/lib/python2.7/site-packages/aldryn-addons.pth
 pipsi uninstall --yes pip-tools && pipsi install https://github.com/aldryncore/pip-tools/archive/1.1.6.2.tar.gz#egg=pip-tools==1.1.6.2
+cp /build/fix_certifi_hack.py /virtualenv/lib/python2.7/site-packages/fix_certifi_hack.py
+cp /build/fix_certifi_hack.pth /virtualenv/lib/python2.7/site-packages/fix_certifi_hack.pth


### PR DESCRIPTION
The certifi bundled certs are all 2048bit by default, but
OpenSSL<1.0.2 has problems loading those sometimes. Since we're
currently using the default python docker image, which uses debian, 
which won't allow easy installation of a newer OpenSSL, we need to
work around that problem.

This patch activates the compatibility mode with 1024bit certs of 
certifi for requests, if certifi and OpenSSL<1.0.2 are installed.
