### PR TITLE
Exclude npm cache from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ENV NPS_VERSION=1.9.32.3\
     NPM_VERSION=2.13.3
 RUN /build/prepare
 
+# Exclude npm cache from the image
+VOLUME /root/.npm
+
 RUN mkdir -p /app && mkdir -p /data
 WORKDIR /app
 VOLUME /data


### PR DESCRIPTION
The `VOLUME /root/.npm` line puts the npm module cache on the build server's hard disk. This lets npm reuse its module cache with each build (making builds faster), and the cache doesn't end up in the docker image (nearly halving the size of the docker image).
